### PR TITLE
Remove invalid Google dependency entry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ google-generativeai
 python-dotenv
 pydantic
 httpx
-google-adk


### PR DESCRIPTION
## Summary
- remove the invalid google-adk requirement entry so pip install succeeds

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d850e6bce08333b898db53ff5ccb84