### PR TITLE
Add mocked tests for triage and webhook flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Automates issue labeling and bug fixes via Gemini AI and PyGithub.
 - Webhook hits FastAPI.
 - Orchestrator routes to agents.
 - Triage labels; if bug, fix agent analyzes/posts comment.
+
+## Reliability Check
+Before demos or pushing changes, run the automated tests to verify the
+mocked Gemini/PyGithub flows and webhook signature guardrails remain intact:
+
+```bash
+pytest
+```

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,131 @@
+import asyncio
+import hashlib
+import hmac
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def triage_module(monkeypatch):
+    """Reload the triage module with a mocked Gemini model."""
+    fake_model = MagicMock()
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "google.generativeai.GenerativeModel",
+        MagicMock(return_value=fake_model),
+    )
+    module = importlib.import_module("agents.triage")
+    module = importlib.reload(module)
+    monkeypatch.setattr(module.genai, "configure", MagicMock())
+    return module, fake_model
+
+
+def test_triage_issue_normalizes_label(triage_module):
+    module, fake_model = triage_module
+    fake_model.generate_content.return_value = MagicMock(text="Bug\n")
+
+    label = module.triage_issue("It crashes when I click")
+
+    assert label == "bug"
+    fake_model.generate_content.assert_called_once()
+
+
+def test_triage_issue_defaults_on_unknown_label(triage_module):
+    module, fake_model = triage_module
+    fake_model.generate_content.return_value = MagicMock(text="other")
+
+    label = module.triage_issue("Feature request: add dark mode")
+
+    assert label == "question"
+
+
+def test_triage_issue_handles_exceptions(triage_module):
+    module, fake_model = triage_module
+    fake_model.generate_content.side_effect = RuntimeError("boom")
+
+    label = module.triage_issue("Any update?")
+
+    assert label == "question"
+
+
+def test_orchestrate_issue_labels_and_triggers_fix(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    orchestrator = importlib.import_module("src.orchestrator")
+    orchestrator = importlib.reload(orchestrator)
+
+    mock_github_instance = MagicMock()
+    mock_repo = MagicMock()
+    mock_issue = MagicMock()
+    mock_repo.get_issue.return_value = mock_issue
+    mock_github_instance.get_repo.return_value = mock_repo
+
+    monkeypatch.setattr(orchestrator, "Github", MagicMock(return_value=mock_github_instance))
+    monkeypatch.setattr(orchestrator, "triage_issue", MagicMock(return_value="bug"))
+    mock_fix = AsyncMock()
+    monkeypatch.setattr(orchestrator, "fix_bug", mock_fix)
+
+    payload = {
+        "action": "opened",
+        "issue": {"number": 42, "title": "Bug", "body": "Steps"},
+        "repository": {"full_name": "octo/demo"},
+    }
+
+    asyncio.run(orchestrator.orchestrate_issue(payload))
+
+    mock_issue.add_to_labels.assert_called_once_with("bug")
+    mock_fix.assert_awaited_once_with(42, "octo/demo", mock_issue)
+
+
+@pytest.fixture
+def main_module(monkeypatch):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
+    module = importlib.import_module("src.main")
+    module = importlib.reload(module)
+    return module
+
+
+def _signature(secret: str, payload: bytes) -> str:
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def test_webhook_rejects_invalid_signature(monkeypatch, main_module):
+    client = TestClient(main_module.app)
+    monkeypatch.setattr(main_module, "orchestrate_issue", AsyncMock())
+
+    payload = json.dumps({"action": "opened", "issue": {}, "repository": {}}).encode()
+    headers = {"X-Hub-Signature-256": _signature("wrong", payload)}
+
+    response = client.post("/webhook", data=payload, headers=headers)
+
+    assert response.status_code == 403
+
+
+def test_webhook_accepts_valid_signature(monkeypatch, main_module):
+    orchestrate_mock = AsyncMock()
+    monkeypatch.setattr(main_module, "orchestrate_issue", orchestrate_mock)
+    client = TestClient(main_module.app)
+
+    payload_dict = {
+        "action": "opened",
+        "issue": {"number": 5, "title": "Bug", "body": "Boom"},
+        "repository": {"full_name": "octo/demo"},
+    }
+    payload = json.dumps(payload_dict).encode()
+    headers = {"X-Hub-Signature-256": _signature("super-secret", payload)}
+
+    response = client.post("/webhook", data=payload, headers=headers)
+
+    assert response.status_code == 200
+    orchestrate_mock.assert_awaited_once_with(payload_dict)


### PR DESCRIPTION
## Summary
- add pytest coverage that exercises triage labeling, orchestrator behavior, and webhook signature validation using mocked Gemini and PyGithub clients
- document a reliability check in the README so hackathon demos include running the new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d850eb2dcc8333a96cec466f6ea93c