### PR TITLE
Offload GitHub operations to threads

### DIFF
--- a/agents/fix.py
+++ b/agents/fix.py
@@ -1,33 +1,68 @@
+import asyncio
+import logging
 import os
 import re
-import asyncio
+from typing import Dict, Iterable
+
 from github import Github
 import google.generativeai as genai
-model = genai.GenerativeModel('gemini-2.5-pro')
+
+
+logger = logging.getLogger(__name__)
+model = genai.GenerativeModel("gemini-2.5-pro")
+
+
+def _get_repo(token: str, repo_full_name: str):
+    github = Github(token)
+    return github.get_repo(repo_full_name)
+
+
+def _get_file_snippets(repo, file_paths: Iterable[str]) -> Dict[str, str]:
+    contents: Dict[str, str] = {}
+    for path in file_paths:
+        try:
+            raw = repo.get_contents(path)
+            contents[path] = raw.decoded_content.decode()[:4000]
+        except Exception:
+            logger.debug("Unable to fetch contents for %s", path, exc_info=True)
+    return contents
+
+
+async def _call_in_thread(func, *args, **kwargs):
+    return await asyncio.to_thread(func, *args, **kwargs)
+
 
 async def fix_bug(issue_number, repo_full_name, gh_issue):
     genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-    g = Github(os.getenv("GITHUB_TOKEN"))
-    repo = g.get_repo(repo_full_name)
-    issue_body = gh_issue.body or ''
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        logger.error("GITHUB_TOKEN is not configured; skipping fix attempt.")
+        return
 
-    # File parsing from diagram: Regex for paths in body
-    file_paths = re.findall(r'[\w/]+\.(py|js|ts|md)', issue_body)[:3]
-    file_contents = {}
-    for path in file_paths:
-        try:
-            content = repo.get_contents(path).decoded_content.decode()[:4000]
-            file_contents[path] = content
-        except:
-            pass
+    issue_body = gh_issue.body or ""
 
-    prompt = f"Analyze bug: {gh_issue.title} {issue_body}. Files: {file_contents}. Suggest fix code."
+    file_paths = re.findall(r"[\w/]+\.(py|js|ts|md)", issue_body)[:3]
+    repo = await _call_in_thread(_get_repo, token, repo_full_name)
+    file_contents = await _call_in_thread(_get_file_snippets, repo, file_paths)
+
+    prompt = (
+        f"Analyze bug: {gh_issue.title} {issue_body}. "
+        f"Files: {file_contents}. Suggest fix code."
+    )
+
     try:
-        response = await asyncio.to_thread(model.generate_content, prompt)  # Async wrapper
+        response = await _call_in_thread(model.generate_content, prompt)
         fix_suggestion = response.text
-        comment = f"🤖 AI Fix Suggestion for #{issue_number}:\n```python\n{fix_suggestion}\n```"
-        gh_issue.create_comment(comment)
-        print("[fix_bug] Comment posted.")
-    except Exception as e:
-        print("[fix_bug] AI/Comment error:", e)
-        gh_issue.create_comment("🤖 Fix attempt failed—human needed.")
+        comment = (
+            f"🤖 AI Fix Suggestion for #{issue_number}:\n"
+            f"```python\n{fix_suggestion}\n```"
+        )
+        await _call_in_thread(gh_issue.create_comment, comment)
+        logger.info("Posted AI fix suggestion for issue #%s", issue_number)
+    except Exception:
+        logger.exception(
+            "fix_bug: AI suggestion or comment failed for issue #%s", issue_number
+        )
+        await _call_in_thread(
+            gh_issue.create_comment, "🤖 Fix attempt failed—human needed."
+        )

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,17 +1,29 @@
+import asyncio
 import logging
 import os
+
 from github import Github
+
 from agents.triage import triage_issue
 from agents.fix import fix_bug
 
 
-# Made the function async to handle async agent calls.
 logger = logging.getLogger(__name__)
 
 
-async def orchestrate_issue(payload: dict):
-    g = Github(os.getenv("GITHUB_TOKEN"))
+async def _call_in_thread(func, *args, **kwargs):
+    """Proxy around asyncio.to_thread to simplify testing."""
+    return await asyncio.to_thread(func, *args, **kwargs)
 
+
+def _fetch_repo_and_issue(token: str, repo_full: str, issue_num: int):
+    github = Github(token)
+    repo = github.get_repo(repo_full)
+    issue = repo.get_issue(number=issue_num)
+    return repo, issue
+
+
+async def orchestrate_issue(payload: dict):
     issue_data = payload.get("issue", {})
     repo_full = payload.get("repository", {}).get("full_name")
     issue_num = issue_data.get("number")
@@ -20,21 +32,26 @@ async def orchestrate_issue(payload: dict):
         logger.warning("Orchestrator: Missing repo/issue info.")
         return
 
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        logger.error("GITHUB_TOKEN is not configured; cannot interact with GitHub.")
+        return
+
     issue_text = f"{issue_data.get('title', '')}\n\n{issue_data.get('body', '')}"
     label = triage_issue(issue_text)
 
     try:
-        repo = g.get_repo(repo_full)
-        gh_issue = repo.get_issue(number=issue_num)
+        _, gh_issue = await _call_in_thread(_fetch_repo_and_issue, token, repo_full, issue_num)
 
         if label:
-            gh_issue.add_to_labels(label)
+            await _call_in_thread(gh_issue.add_to_labels, label)
             logger.info("Orchestrator: Added label '%s' to issue #%s.", label, issue_num)
 
         if label == "bug":
             logger.info("Orchestrator: Label is 'bug', handing off to fix_bug agent.")
-            # await the async fix_bug function.
             await fix_bug(issue_num, repo_full, gh_issue)
 
-    except Exception as e:
-        logger.exception("Orchestrator: An error occurred while processing issue #%s", issue_num)
+    except Exception:
+        logger.exception(
+            "Orchestrator: An error occurred while processing issue #%s", issue_num
+        )


### PR DESCRIPTION
## Summary
- offload PyGithub repository lookups, file reads, and comment posting in the fixer to background threads with improved logging and guardrails
- route orchestrator GitHub interactions through asyncio.to_thread to prevent blocking the event loop when triaging issues
- extend the agent test suite with thread offloading assertions and an anyio backend fixture

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d84e59820883338a6612e1efd10e36